### PR TITLE
Set lang attr to title

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,7 +20,7 @@ const clients: { nameKey: string, url: string, asideKey: string }[] = [
 const Index = ({ t, i18n }) => (
     <>
         <Head>
-            <title>{t('title')}</title>
+            <title lang={i18n.language}>{t('title')}</title>
         </Head>
         <div id="locales">
             <span>Language: </span>


### PR DESCRIPTION
## Why

In Bingbot, title's lang attribute is respected for language detection.